### PR TITLE
Fix possible fix(deps): 18 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	entgo.io/ent v0.14.6
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
-	github.com/labstack/echo/v4 v4.13.4
+	github.com/labstack/echo/v4 v4.15.3
 	github.com/lib/pq v1.12.3
 	github.com/minio/minio-go/v7 v7.2.1
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/crypto v0.51.0
+	golang.org/x/crypto v0.55.0
 )
 
 require (
@@ -44,10 +44,10 @@ require (
 	github.com/zclconf/go-cty-yaml v1.1.0 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
+	golang.org/x/mod v0.40.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect


### PR DESCRIPTION
Proposing a fix for something flagged in `go.mod`. It is around line 1.

This CRITICAL vulnerability in golang.org/x/crypto causes the SSH server to silently ignore source-address restrictions configured in non-public-key authentication callbacks (Password, KeyboardInteractive, GSSAPI, etc.). Attackers can bypass IP-based access controls and gain unauthorized remote access. Risk Level: CRITICAL due to complete bypass of network-level authentication restrictions.

Updates all vulnerable direct and indirect dependencies to versions that fix the reported CVEs.

For reference: rule `CVE-2026-56854`. Rated critical.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
