### PR TITLE
Fix possible fix(deps): 18 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,53 +3,53 @@ module go-starter
 go 1.25.1
 
 require (
-	entgo.io/ent v0.14.6
-	github.com/golang-jwt/jwt/v5 v5.3.0
-	github.com/google/uuid v1.6.0
-	github.com/labstack/echo/v4 v4.13.4
-	github.com/lib/pq v1.12.3
-	github.com/minio/minio-go/v7 v7.2.1
-	github.com/stretchr/testify v1.11.1
-	golang.org/x/crypto v0.51.0
+    entgo.io/ent v0.14.6
+    github.com/golang-jwt/jwt/v5 v5.3.0
+    github.com/google/uuid v1.6.0
+    github.com/labstack/echo/v4 v4.15.3
+    github.com/lib/pq v1.12.3
+    github.com/minio/minio-go/v7 v7.2.1
+    github.com/stretchr/testify v1.11.1
+    golang.org/x/crypto v0.55.0
 )
 
 require (
-	ariga.io/atlas v0.36.2-0.20250730182955-2c6300d0a3e1 // indirect
-	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/bmatcuk/doublestar v1.3.4 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/go-openapi/inflect v0.19.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.18.1 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
-	github.com/klauspost/crc32 v1.3.0 // indirect
-	github.com/labstack/gommon v0.4.2 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-sqlite3 v1.14.44 // indirect
-	github.com/minio/crc64nvme v1.1.1 // indirect
-	github.com/minio/md5-simd v1.1.2 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/philhofer/fwd v1.2.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rs/xid v1.6.0 // indirect
-	github.com/tinylib/msgp v1.6.1 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasttemplate v1.2.2 // indirect
-	github.com/zclconf/go-cty v1.14.4 // indirect
-	github.com/zclconf/go-cty-yaml v1.1.0 // indirect
-	github.com/zeebo/xxh3 v1.1.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.11.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/ini.v1 v1.67.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+    ariga.io/atlas v0.36.2-0.20250730182955-2c6300d0a3e1 // indirect
+    github.com/agext/levenshtein v1.2.3 // indirect
+    github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+    github.com/bmatcuk/doublestar v1.3.4 // indirect
+    github.com/cespare/xxhash/v2 v2.3.0 // indirect
+    github.com/davecgh/go-spew v1.1.1 // indirect
+    github.com/dustin/go-humanize v1.0.1 // indirect
+    github.com/go-openapi/inflect v0.19.0 // indirect
+    github.com/google/go-cmp v0.7.0 // indirect
+    github.com/hashicorp/hcl/v2 v2.18.1 // indirect
+    github.com/klauspost/compress v1.18.6 // indirect
+    github.com/klauspost/cpuid/v2 v2.2.11 // indirect
+    github.com/klauspost/crc32 v1.3.0 // indirect
+    github.com/labstack/gommon v0.4.2 // indirect
+    github.com/mattn/go-colorable v0.1.14 // indirect
+    github.com/mattn/go-isatty v0.0.20 // indirect
+    github.com/mattn/go-sqlite3 v1.14.44 // indirect
+    github.com/minio/crc64nvme v1.1.1 // indirect
+    github.com/minio/md5-simd v1.1.2 // indirect
+    github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+    github.com/philhofer/fwd v1.2.0 // indirect
+    github.com/pmezard/go-difflib v1.0.0 // indirect
+    github.com/rs/xid v1.6.0 // indirect
+    github.com/tinylib/msgp v1.6.1 // indirect
+    github.com/valyala/bytebufferpool v1.0.0 // indirect
+    github.com/valyala/fasttemplate v1.2.2 // indirect
+    github.com/zclconf/go-cty v1.14.4 // indirect
+    github.com/zclconf/go-cty-yaml v1.1.0 // indirect
+    github.com/zeebo/xxh3 v1.1.0 // indirect
+    go.yaml.in/yaml/v3 v3.0.4 // indirect
+    golang.org/x/mod v0.40.0 // indirect
+    golang.org/x/net v0.56.0 // indirect
+    golang.org/x/sys v0.44.0 // indirect
+    golang.org/x/text v0.39.0 // indirect
+    golang.org/x/time v0.11.0 // indirect
+    gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+    gopkg.in/ini.v1 v1.67.2 // indirect
+    gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Proposing a fix for something flagged in `go.mod`. It is around line 1.

This CRITICAL vulnerability in golang.org/x/crypto causes the SSH server to silently ignore source-address restrictions configured in non-public-key authentication callbacks (Password, KeyboardInteractive, GSSAPI, etc.). Attackers can bypass IP-based access controls and gain unauthorized remote access. Risk Level: CRITICAL due to complete bypass of network-level authentication restrictions.

Update vulnerable dependencies to versions that address the reported CVEs.

For reference: rule `CVE-2026-56854`. Rated critical.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
